### PR TITLE
Fix build issues with OpenEXR and Sixel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,9 @@ set(VV_SRC
 )
 
 add_executable(vv ${VV_SRC})
+target_include_directories(vv PRIVATE
+    ${SIXEL_INCLUDE_DIRS}
+)
 target_link_libraries(vv PRIVATE
     mcoreutil
     mcoreimage

--- a/src/image/ExrLoader.hpp
+++ b/src/image/ExrLoader.hpp
@@ -2,13 +2,15 @@
 
 #include <memory>
 
-#include <ImfRgbaFile.h>
+#include <OpenEXRConfig.h>
 
 #include "util/FileWrapper.hpp"
 #include "util/NoCopy.hpp"
 
 class Bitmap;
 class ExrStream;
+
+namespace OPENEXR_IMF_INTERNAL_NAMESPACE { class RgbaInputFile; }
 
 class ExrLoader
 {
@@ -23,7 +25,7 @@ public:
 
 private:
     std::unique_ptr<ExrStream> m_stream;
-    std::unique_ptr<Imf::RgbaInputFile> m_exr;
+    std::unique_ptr<OPENEXR_IMF_INTERNAL_NAMESPACE::RgbaInputFile> m_exr;
 
     bool m_valid;
 };

--- a/src/image/ExrLoader.hpp
+++ b/src/image/ExrLoader.hpp
@@ -2,13 +2,13 @@
 
 #include <memory>
 
+#include <ImfRgbaFile.h>
+
 #include "util/FileWrapper.hpp"
 #include "util/NoCopy.hpp"
 
 class Bitmap;
 class ExrStream;
-
-namespace Imf_3_2 { class RgbaInputFile; }
 
 class ExrLoader
 {
@@ -23,7 +23,7 @@ public:
 
 private:
     std::unique_ptr<ExrStream> m_stream;
-    std::unique_ptr<Imf_3_2::RgbaInputFile> m_exr;
+    std::unique_ptr<Imf::RgbaInputFile> m_exr;
 
     bool m_valid;
 };


### PR DESCRIPTION
- Add SIXEL_INCLUDE_DIRS to the target_include_directories for vv
- Just #include ImgRgbaFile.h to get the RgbaInputFile definition; with a local install of Imf_3_3, for example, hardcoding to Imf_3_2 causes build failures.