### PR TITLE
Fix segfault in arg parsing

### DIFF
--- a/src/tools/vv/vv.cpp
+++ b/src/tools/vv/vv.cpp
@@ -351,6 +351,7 @@ int main( int argc, char** argv )
         { "noanim", no_argument, nullptr, 'A' },
         { "write", required_argument, nullptr, 'w' },
         { "help", no_argument, nullptr, OptHelp },
+	{ nullptr, 0, nullptr, 0 }, // terminator
     };
 
     enum class GfxMode


### PR DESCRIPTION
If you were to pass in an unknown long option (e.g. --version), vv would segfault due to accessing out-of-bounds memory.  According to the manpage for getopt, this is because "the last element of the [longopts] array has to be filled with zeros".  This solves that.